### PR TITLE
Fix dataset loader bug

### DIFF
--- a/dataset/gsm8k_loader.py
+++ b/dataset/gsm8k_loader.py
@@ -86,9 +86,10 @@ class GSM8KLoader:
         slice_iter = itertools.islice(self._buffered_iterator, n)
         examples = []
         for raw in slice_iter:
-            q_text = raw.get("question", "").strip() 
-            raw_ans = raw.get("answer", "").strip() 
-            answers_list = [raw_ans] if raw_ans != "" else []
+            q_text = raw.get("question", "").strip()
+            raw_ans = raw.get("answer", "").strip()
+            final_ans = self._extract_final_answer(raw_ans)
+            answers_list = [final_ans] if final_ans != "" else []
 
             examples.append({
                 "question": q_text,


### PR DESCRIPTION
## Summary
- ensure `GSM8KLoader.get_examples` applies the same final-answer extraction logic as the iterator

## Testing
- `python -m py_compile dataset/gsm8k_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_68412da6b8d4832aaaaafd681d8f0d92